### PR TITLE
Add --only_read flag to only dump raw_tables.txt

### DIFF
--- a/times_excel_reader.py
+++ b/times_excel_reader.py
@@ -20,6 +20,11 @@ if __name__ == "__main__":
         help="Ground truth directory to compare with output",
     )
     args_parser.add_argument("--dd", action="store_true", help="Output DD files")
+    args_parser.add_argument(
+        "--only_read",
+        action="store_true",
+        help="Read xlsx files and stop after outputting raw_tables.txt",
+    )
     args_parser.add_argument("--use_pkl", action="store_true")
     args = args_parser.parse_args()
 
@@ -38,6 +43,12 @@ if __name__ == "__main__":
         print(f"Loading {len(input_files)} files from {args.input[0]}")
     else:
         input_files = args.input
+
+    if args.only_read:
+        tables = times_reader.convert_xl_to_times(
+            input_files, args.output_dir, mappings, args.use_pkl, stop_after_read=True
+        )
+        sys.exit(0)
 
     tables = times_reader.convert_xl_to_times(
         input_files, args.output_dir, mappings, args.use_pkl

--- a/times_reader/main.py
+++ b/times_reader/main.py
@@ -108,7 +108,7 @@ def convert_xl_to_times(
     if stop_after_read:
         # Convert absolute paths to relative paths to enable comparing raw_tables.txt across machines
         raw_tables.sort(key=lambda x: (x.filename, x.sheetname, x.range))
-        input_dir = os.path.commonpath((t.filename for t in raw_tables))
+        input_dir = os.path.commonpath([t.filename for t in raw_tables])
         raw_tables = [strip_filename_prefix(t, input_dir) for t in raw_tables]
 
     dump_tables(raw_tables, os.path.join(output_dir, "raw_tables.txt"))


### PR DESCRIPTION
This PR adds an only-read mode `--only_read` to the tool, in which it only reads the input Excel files and stops after dumping `raw_tables.txt`. It also strips any absolute path prefix from the filenames so that the resulting file can be stored in git/version-control and compared across machines. (H/t @willcattoneeca )

Example invocation:
```
python times_excel_reader.py /path/to/model/ --output_dir /path/to/model/raw_table_summary/ --only_read
```

(CI is failing because of a spurious type error, I'll figure out how to fix it)

Fixes #96 