### PR TITLE
Add pyright to pre-commit, update readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,18 +22,17 @@ jobs:
       - name: Install packages
         working-directory: times-excel-reader
         run: |
+          python -m venv .venv
+          source .venv/bin/activate
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Check code formatting
         working-directory: times-excel-reader
         run: |
+          source .venv/bin/activate
           pre-commit install
           pre-commit run --all-files
-
-      - uses: jakebailey/pyright-action@v1 # Type checking
-        with:
-          version: 1.1.304
 
       # ---------- Prepare ETSAP Demo models
 
@@ -94,6 +93,7 @@ jobs:
         # Save the return code to retcode.txt so that the next step can fail the action
         # if run_benchmarks.py failed.
         run: |
+          source .venv/bin/activate
           export PATH=$PATH:$GITHUB_WORKSPACE/GAMS/gams44.1_linux_x64_64_sfx
           (python utils/run_benchmarks.py benchmarks.yml \
               --dd --times_dir $GITHUB_WORKSPACE/TIMES_model \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,8 @@ repos:
     rev: v1.1.304
     hooks:
       - id: pyright
+        # A bit annoying, but we need to specify dependencies here because I can't get it
+        # to read requirements.txt, and the pyright pre-commit hook uses its own virtualenv
+        # https://github.com/RobertCraigie/pyright-python#pre-commit
+        # https://github.com/pre-commit/pre-commit/issues/730
+        additional_dependencies: [pandas>=1.5]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,15 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
--   repo: https://github.com/psf/black
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
     rev: 22.8.0
     hooks:
-    -   id: black
+      - id: black
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.304
+    hooks:
+      - id: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,3 @@ repos:
     rev: v1.1.304
     hooks:
       - id: pyright
-        # A bit annoying, but we need to specify dependencies here because I can't get it
-        # to read requirements.txt, and the pyright pre-commit hook uses its own virtualenv
-        # https://github.com/RobertCraigie/pyright-python#pre-commit
-        # https://github.com/pre-commit/pre-commit/issues/730
-        additional_dependencies: [pandas>=1.5]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ It is fully explained in the [TIMES Model Documentation](https://iea-etsap.org/i
 
 The Excel input format accepted by this tool is documented in the [TIMES Model Documentation PART IV](https://iea-etsap.org/docs/Documentation_for_the_TIMES_Model-Part-IV.pdf).  Additional table types are documented in the [VEDA support forum](https://forum.kanors-emr.org/printthread.php?tid=140).  Example inputs are available at https://github.com/kanors-emr/Model_Demo_Adv_Veda
 
+## Basic Usage
+
+After installing the required dependencies (see below), run the following command to see the basic usage and available options:
+```bash
+python times_excel_reader.py --help
+```
+
 ## Development Setup
 
 We recommend using a Python virtual environment:
@@ -18,7 +25,14 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-We use the [black](https://pypi.org/project/black/) code formatter. The `pip` command above will install it along with other requirements. Additionally, you can install a git pre-commit that will ensure that your changes are formatted before creating new commits:
+We use the [black](https://pypi.org/project/black/) code formatter. The `pip` command above will install it along with other requirements.
+
+We also use the [pyright](https://github.com/microsoft/pyright/) type checker -- our GitHub Actions check will fail if pyright detects any type errors in your code. You can install pyright in your virtual environment and check your code by running these commands in the root of the repository:
+```bash
+pip install pyright==1.1.304
+pyright
+```
+Additionally, you can install a git pre-commit that will ensure that your changes are formatted and pyright detects no issues before creating new commits:
 ```bash
 pre-commit install
 ```

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -11,7 +11,5 @@
   "reportMissingImports": true,
   "reportMissingTypeStubs": false,
   "pythonVersion": "3.10",
-  "pythonPlatform": "All",
-  "venv": ".venv",
-  "venvPath": "."
+  "pythonPlatform": "All"
 }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -11,5 +11,7 @@
   "reportMissingImports": true,
   "reportMissingTypeStubs": false,
   "pythonVersion": "3.10",
-  "pythonPlatform": "All"
+  "pythonPlatform": "All",
+  "venv": ".venv",
+  "venvPath": "."
 }


### PR DESCRIPTION
I added pyright to the pre-commit, so that we are warned when we create a commit (as opposed to after pushing and when CI runs) when there is a type error.

Unfortunately, the [pyright pre-commit](https://github.com/RobertCraigie/pyright-python#pre-commit) is installed in its own virtualenv and doesn't [support](https://github.com/pre-commit/pre-commit/issues/730) using `requirement.txt`, so it would have been cumbersome to duplicate all our dependencies in the pre-commit configuration file. So I've instead modified the CI to also use a virtual env, and modified the pyright configuration to use that virtual env.

The upside of this is that the CI setup steps is identical to the local development setup steps. So  we can point new developers to the CI file and say "just copy those steps".