### PR TITLE
Thread a Config class through all transforms

### DIFF
--- a/times_reader/__main__.py
+++ b/times_reader/__main__.py
@@ -1,14 +1,10 @@
 import argparse
 from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
-from importlib import resources
-from itertools import chain
 from pandas.core.frame import DataFrame
 import pandas as pd
 import pickle
 from pathlib import Path
-import json
-import re
 import os
 import sys
 import time
@@ -18,75 +14,10 @@ from . import excel
 from . import transforms
 
 
-def read_mappings(filename: str) -> List[datatypes.TimesXlMap]:
-    """
-    Function to load mappings from a text file between the excel sheets we use as input and
-    the tables we give as output. The mappings have the following structure:
-
-    OUTPUT_TABLE[DATAYEAR,VALUE] = ~TimePeriods(Year,B)
-
-    where OUTPUT_TABLE is the name of the table we output and it includes a list of the
-    different fields or column names it includes. On the other side, TimePeriods is the type
-    of table that we will use as input to produce that table, and the arguments are the
-    columns of that table to use to produce the output. The last argument can be of the
-    form `Attribute:ATTRNAME` which means the output will be filtered to only the rows of
-    the input table that have `ATTRNAME` in the Attribute column.
-
-    The mappings are loaded into TimesXlMap objects. See the description of that class for more
-    information of the different fields they contain.
-
-    :param filename:        Name of the text file containing the mappings.
-    :return:                List of mappings in TimesXlMap format.
-    """
-    mappings = []
-    dropped = []
-    with resources.open_text("times_reader.config", filename) as file:
-        while True:
-            line = file.readline().rstrip()
-            if line == "":
-                break
-            (times, xl) = line.split(" = ")
-            (times_name, times_cols_str) = list(filter(None, re.split("\[|\]", times)))
-            (xl_name, xl_cols_str) = list(filter(None, re.split("\(|\)", xl)))
-            times_cols = times_cols_str.split(",")
-            xl_cols = xl_cols_str.split(",")
-            filter_rows = {}
-            for i, s in enumerate(xl_cols):
-                if ":" in s:
-                    [col_name, col_val] = s.split(":")
-                    filter_rows[col_name.strip().lower()] = col_val.strip()
-            xl_cols = [s.lower() for s in xl_cols if ":" not in s]
-
-            # TODO remove: Filter out mappings that are not yet finished
-            if xl_name != "~TODO" and not any(c.startswith("TODO") for c in xl_cols):
-                col_map = {}
-                assert len(times_cols) <= len(xl_cols)
-                for index, value in enumerate(times_cols):
-                    col_map[value] = xl_cols[index]
-                # Uppercase and validate tags:
-                if xl_name.startswith("~"):
-                    xl_name = xl_name.upper()
-                entry = datatypes.TimesXlMap(
-                    times_name=times_name,
-                    times_cols=times_cols,
-                    xl_name=xl_name,
-                    xl_cols=xl_cols,
-                    col_map=col_map,
-                    filter_rows=filter_rows,
-                )
-                mappings.append(entry)
-            else:
-                dropped.append(line)
-
-    if len(dropped) > 0:
-        print(f"WARNING: Dropping {len(dropped)} mappings that are not yet complete")
-    return mappings
-
-
 def convert_xl_to_times(
     input_files: List[str],
     output_dir: str,
-    mappings: List[datatypes.TimesXlMap],
+    config: datatypes.Config,
     use_pkl: bool,
     stop_after_read: bool = False,
 ) -> Dict[str, DataFrame]:
@@ -126,8 +57,8 @@ def convert_xl_to_times(
         transforms.generate_dummy_processes,
         transforms.normalize_tags_columns_attrs,
         transforms.remove_fill_tables,
-        lambda tables: [transforms.remove_comment_rows(t) for t in tables],
-        lambda tables: [transforms.remove_comment_cols(t) for t in tables],
+        lambda config, tables: [transforms.remove_comment_rows(t) for t in tables],
+        lambda config, tables: [transforms.remove_comment_cols(t) for t in tables],
         transforms.remove_tables_with_formulas,  # slow
         transforms.process_transform_insert,
         transforms.process_processes,
@@ -158,17 +89,17 @@ def convert_xl_to_times(
         transforms.convert_aliases,
         transforms.rename_cgs,
         transforms.convert_to_string,
-        lambda tables: dump_tables(
+        lambda config, tables: dump_tables(
             tables, os.path.join(output_dir, "merged_tables.txt")
         ),
-        lambda tables: produce_times_tables(tables, mappings),
+        lambda config, tables: produce_times_tables(config, tables),
     ]
 
     input = raw_tables
     output = {}
     for transform in transform_list:
         start_time = time.time()
-        output = transform(input)
+        output = transform(config, input)
         end_time = time.time()
         print(
             f"transform {transform.__code__.co_name} took {end_time-start_time:.2f} seconds"
@@ -276,7 +207,7 @@ def compare(
 
 
 def produce_times_tables(
-    input: Dict[str, DataFrame], mappings: List[datatypes.TimesXlMap]
+    config: datatypes.Config, input: Dict[str, DataFrame]
 ) -> Dict[str, DataFrame]:
     print(
         f"produce_times_tables: {len(input)} tables incoming,"
@@ -284,7 +215,7 @@ def produce_times_tables(
     )
     result = {}
     used_tables = set()
-    for mapping in mappings:
+    for mapping in config.times_xl_maps:
         if not mapping.xl_name in input:
             print(
                 f"WARNING: Cannot produce table {mapping.times_name} because input table"
@@ -344,7 +275,7 @@ def produce_times_tables(
 
 
 def write_dd_files(
-    tables: Dict[str, DataFrame], mappings: List[datatypes.TimesXlMap], output_dir: str
+    tables: Dict[str, DataFrame], config: datatypes.Config, output_dir: str
 ):
     os.makedirs(output_dir, exist_ok=True)
     for item in os.listdir(output_dir):
@@ -370,24 +301,12 @@ def write_dd_files(
             )
             yield f"'{row_str}' {val}\n" if row_str else f"{val}\n"
 
-    sets = {m.times_name for m in mappings if "VALUE" not in m.col_map}
-    # We output tables in order by categories: set, subset, subsubset, md-set, and parameter
-    # Category info is in `times-info.json` file TODO merge with times_mapping.txt
-    with resources.open_text("times_reader.config", "times-info.json") as f:
-        table_info = json.load(f)
-    categories = ["set", "subset", "subsubset", "md-set", "parameter"]
-    cat_to_tables = defaultdict(list)
-    for item in table_info:
-        cat_to_tables[item["gams-cat"]].append(item["name"])
-    table_order = chain.from_iterable((sorted(cat_to_tables[c]) for c in categories))
-    unknown_cats = {item["gams-cat"] for item in table_info} - set(categories)
-    if unknown_cats:
-        print(f"WARNING: Unknown categories in times-info.json: {unknown_cats}")
+    sets = {m.times_name for m in config.times_xl_maps if "VALUE" not in m.col_map}
 
     # Compute map fname -> tables: right now ALL_TS -> ts.dd, rest -> output.dd
     tables_in_file = {
         "ts.dd": ["ALL_TS"],
-        "output.dd": [t for t in table_order if t != "ALL_TS"],
+        "output.dd": [t for t in config.dd_table_order if t != "ALL_TS"],
     }
 
     for fname, tablenames in tables_in_file.items():
@@ -460,7 +379,7 @@ def main():
     args_parser.add_argument("--use_pkl", action="store_true")
     args = args_parser.parse_args()
 
-    mappings = read_mappings("times_mapping.txt")
+    config = datatypes.Config("times_mapping.txt", "times-info.json")
 
     if not isinstance(args.input, list) or len(args.input) < 1:
         print(f"ERROR: expected at least 1 input. Got {args.input}")
@@ -478,14 +397,14 @@ def main():
 
     if args.only_read:
         tables = convert_xl_to_times(
-            input_files, args.output_dir, mappings, args.use_pkl, stop_after_read=True
+            input_files, args.output_dir, config, args.use_pkl, stop_after_read=True
         )
         sys.exit(0)
 
-    tables = convert_xl_to_times(input_files, args.output_dir, mappings, args.use_pkl)
+    tables = convert_xl_to_times(input_files, args.output_dir, config, args.use_pkl)
 
     if args.dd:
-        write_dd_files(tables, mappings, args.output_dir)
+        write_dd_files(tables, config, args.output_dir)
     else:
         write_csv_tables(tables, args.output_dir)
 

--- a/times_reader/datatypes.py
+++ b/times_reader/datatypes.py
@@ -1,5 +1,10 @@
+from collections import defaultdict
 from dataclasses import dataclass
-from typing import Dict, List
+from importlib import resources
+from itertools import chain
+import json
+import re
+from typing import Dict, Iterable, List
 from enum import Enum
 from pandas.core.frame import DataFrame
 
@@ -72,6 +77,105 @@ class TimesXlMap:
     xl_cols: List[str]
     col_map: Dict[str, str]
     filter_rows: Dict[str, str]
+
+
+class Config:
+    """Encapsulates all configuration options for a run of the tool, including
+    the mapping betwen excel tables and output tables, categories of tables, etc.
+    """
+
+    times_xl_maps: List[TimesXlMap]
+    dd_table_order: Iterable[str]
+
+    def __init__(self, mapping_file: str, times_info_file: str):
+        self.times_xl_maps = Config._read_mappings(mapping_file)
+        self.dd_table_order = Config._compute_dd_table_order(times_info_file)
+
+    @staticmethod
+    def _compute_dd_table_order(times_info_file: str) -> Iterable[str]:
+        # Read times_info_file and compute dd_table_order:
+        # We output tables in order by categories: set, subset, subsubset, md-set, and parameter
+        with resources.open_text("times_reader.config", times_info_file) as f:
+            table_info = json.load(f)
+        categories = ["set", "subset", "subsubset", "md-set", "parameter"]
+        cat_to_tables = defaultdict(list)
+        for item in table_info:
+            cat_to_tables[item["gams-cat"]].append(item["name"])
+        unknown_cats = {item["gams-cat"] for item in table_info} - set(categories)
+        if unknown_cats:
+            print(f"WARNING: Unknown categories in times-info.json: {unknown_cats}")
+        return chain.from_iterable((sorted(cat_to_tables[c]) for c in categories))
+
+    @staticmethod
+    def _read_mappings(filename: str) -> List[TimesXlMap]:
+        """
+        Function to load mappings from a text file between the excel sheets we use as input and
+        the tables we give as output. The mappings have the following structure:
+
+        OUTPUT_TABLE[DATAYEAR,VALUE] = ~TimePeriods(Year,B)
+
+        where OUTPUT_TABLE is the name of the table we output and it includes a list of the
+        different fields or column names it includes. On the other side, TimePeriods is the type
+        of table that we will use as input to produce that table, and the arguments are the
+        columns of that table to use to produce the output. The last argument can be of the
+        form `Attribute:ATTRNAME` which means the output will be filtered to only the rows of
+        the input table that have `ATTRNAME` in the Attribute column.
+
+        The mappings are loaded into TimesXlMap objects. See the description of that class for more
+        information of the different fields they contain.
+
+        :param filename:        Name of the text file containing the mappings.
+        :return:                List of mappings in TimesXlMap format.
+        """
+        mappings = []
+        dropped = []
+        with resources.open_text("times_reader.config", filename) as file:
+            while True:
+                line = file.readline().rstrip()
+                if line == "":
+                    break
+                (times, xl) = line.split(" = ")
+                (times_name, times_cols_str) = list(
+                    filter(None, re.split("\[|\]", times))
+                )
+                (xl_name, xl_cols_str) = list(filter(None, re.split("\(|\)", xl)))
+                times_cols = times_cols_str.split(",")
+                xl_cols = xl_cols_str.split(",")
+                filter_rows = {}
+                for i, s in enumerate(xl_cols):
+                    if ":" in s:
+                        [col_name, col_val] = s.split(":")
+                        filter_rows[col_name.strip().lower()] = col_val.strip()
+                xl_cols = [s.lower() for s in xl_cols if ":" not in s]
+
+                # TODO remove: Filter out mappings that are not yet finished
+                if xl_name != "~TODO" and not any(
+                    c.startswith("TODO") for c in xl_cols
+                ):
+                    col_map = {}
+                    assert len(times_cols) <= len(xl_cols)
+                    for index, value in enumerate(times_cols):
+                        col_map[value] = xl_cols[index]
+                    # Uppercase and validate tags:
+                    if xl_name.startswith("~"):
+                        xl_name = xl_name.upper()
+                    entry = TimesXlMap(
+                        times_name=times_name,
+                        times_cols=times_cols,
+                        xl_name=xl_name,
+                        xl_cols=xl_cols,
+                        col_map=col_map,
+                        filter_rows=filter_rows,
+                    )
+                    mappings.append(entry)
+                else:
+                    dropped.append(line)
+
+        if len(dropped) > 0:
+            print(
+                f"WARNING: Dropping {len(dropped)} mappings that are not yet complete"
+            )
+        return mappings
 
 
 class Tag(str, Enum):

--- a/times_reader/transforms.py
+++ b/times_reader/transforms.py
@@ -328,6 +328,7 @@ def remove_comment_cols(table: datatypes.EmbeddedXlTable) -> datatypes.EmbeddedX
 
 
 def remove_tables_with_formulas(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     """
@@ -351,6 +352,7 @@ def remove_tables_with_formulas(
 
 
 def normalize_tags_columns_attrs(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     """
@@ -384,6 +386,7 @@ def normalize_tags_columns_attrs(
 
 
 def include_tables_source(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     """
@@ -398,7 +401,9 @@ def include_tables_source(
     return [include_table_source(table) for table in tables]
 
 
-def merge_tables(tables: List[datatypes.EmbeddedXlTable]) -> Dict[str, DataFrame]:
+def merge_tables(
+    config: datatypes.Config, tables: List[datatypes.EmbeddedXlTable]
+) -> Dict[str, DataFrame]:
     """
     Merge all tables in 'tables' with the same table tag, as long as they share the same
     column field values. Print a warning for those that don't share the same column values.
@@ -432,6 +437,7 @@ def merge_tables(tables: List[datatypes.EmbeddedXlTable]) -> Dict[str, DataFrame
 
 
 def process_flexible_import_tables(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     """
@@ -622,6 +628,7 @@ def process_flexible_import_tables(
 
 
 def process_user_constraint_tables(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     """
@@ -751,6 +758,7 @@ def process_user_constraint_tables(
 
 
 def fill_in_missing_values(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     """
@@ -878,6 +886,7 @@ def expand_rows(table: datatypes.EmbeddedXlTable) -> datatypes.EmbeddedXlTable:
 
 
 def remove_invalid_values(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     """
@@ -915,6 +924,7 @@ def remove_invalid_values(
 
 
 def process_units(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     commodity_units = set()
@@ -995,6 +1005,7 @@ def process_units(
 
 
 def process_time_periods(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     start_year = utils.get_scalar(datatypes.Tag.start_year, tables)
@@ -1022,6 +1033,7 @@ def process_time_periods(
 
 
 def generate_all_regions(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     """
@@ -1051,6 +1063,7 @@ def generate_all_regions(
 
 
 def capitalise_attributes(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     """
@@ -1071,6 +1084,7 @@ def capitalise_attributes(
 
 
 def apply_fixups(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     reg_com_flows = utils.single_table(tables, "ProcessTopology").dataframe.copy()
@@ -1131,6 +1145,7 @@ def apply_fixups(
 
 
 def extract_commodity_groups(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     process_tables = [t for t in tables if t.tag == datatypes.Tag.fi_process]
@@ -1260,6 +1275,7 @@ def extract_commodity_groups(
 
 
 def generate_top_ire(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     """
@@ -1328,6 +1344,7 @@ def generate_top_ire(
 
 
 def fill_in_missing_pcgs(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     """
@@ -1386,6 +1403,7 @@ def fill_in_missing_pcgs(
 
 
 def remove_fill_tables(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     # These tables collect data from elsewhere and update the table itself or a region below
@@ -1401,6 +1419,7 @@ def remove_fill_tables(
 
 
 def process_commodity_emissions(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     regions = utils.single_column(tables, datatypes.Tag.book_regions_map, "region")
@@ -1437,6 +1456,7 @@ def process_commodity_emissions(
 
 
 def process_commodities(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     regions = ",".join(
@@ -1461,7 +1481,9 @@ def process_commodities(
     return result
 
 
-def process_years(tables: Dict[str, DataFrame]) -> Dict[str, DataFrame]:
+def process_years(
+    config: datatypes.Config, tables: Dict[str, DataFrame]
+) -> Dict[str, DataFrame]:
     # Datayears is the set of all years in ~FI_T's Year column
     # We ignore values < 1000 because those signify interpolation/extrapolation rules
     # (see Table 8 of Part IV of the Times Documentation)
@@ -1492,6 +1514,7 @@ def process_years(tables: Dict[str, DataFrame]) -> Dict[str, DataFrame]:
 
 
 def process_processes(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     result = []
@@ -1534,6 +1557,7 @@ def process_processes(
 
 
 def process_topology(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     """
@@ -1577,7 +1601,9 @@ def process_topology(
 
 
 def generate_dummy_processes(
-    tables: List[datatypes.EmbeddedXlTable], include_dummy_processes=True
+    config: datatypes.Config,
+    tables: List[datatypes.EmbeddedXlTable],
+    include_dummy_processes=True,
 ) -> List[datatypes.EmbeddedXlTable]:
     """
     Define dummy processes and specify default cost data for them to ensure that a TIMES model
@@ -1631,6 +1657,7 @@ def generate_dummy_processes(
 
 # TODO: should we rename this to something more general, since it takes care of more than tfm_ins?
 def process_transform_insert(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     regions = utils.single_column(tables, datatypes.Tag.book_regions_map, "region")
@@ -1771,6 +1798,7 @@ def process_transform_insert(
 
 
 def process_transform_availability(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     result = []
@@ -1908,7 +1936,9 @@ def generate_topology_dictionary(tables: Dict[str, DataFrame]) -> Dict[str, Data
     return dictionary
 
 
-def process_uc_wildcards(tables: Dict[str, DataFrame]) -> Dict[str, DataFrame]:
+def process_uc_wildcards(
+    config: datatypes.Config, tables: Dict[str, DataFrame]
+) -> Dict[str, DataFrame]:
     tag = datatypes.Tag.uc_t
 
     def make_str(df):
@@ -1950,7 +1980,9 @@ def process_uc_wildcards(tables: Dict[str, DataFrame]) -> Dict[str, DataFrame]:
     return tables
 
 
-def process_wildcards(tables: Dict[str, DataFrame]) -> Dict[str, DataFrame]:
+def process_wildcards(
+    config: datatypes.Config, tables: Dict[str, DataFrame]
+) -> Dict[str, DataFrame]:
     dictionary = generate_topology_dictionary(tables)
 
     for tag in [
@@ -2059,6 +2091,7 @@ def process_wildcards(tables: Dict[str, DataFrame]) -> Dict[str, DataFrame]:
 
 
 def process_time_slices(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     def timeslices_table(
@@ -2184,7 +2217,9 @@ def process_time_slices(
     return result
 
 
-def convert_to_string(input: Dict[str, DataFrame]) -> Dict[str, DataFrame]:
+def convert_to_string(
+    config: datatypes.Config, input: Dict[str, DataFrame]
+) -> Dict[str, DataFrame]:
     output = {}
     for key, value in input.items():
         output[key] = value.applymap(
@@ -2193,7 +2228,9 @@ def convert_to_string(input: Dict[str, DataFrame]) -> Dict[str, DataFrame]:
     return output
 
 
-def convert_aliases(input: Dict[str, DataFrame]) -> Dict[str, DataFrame]:
+def convert_aliases(
+    config: datatypes.Config, input: Dict[str, DataFrame]
+) -> Dict[str, DataFrame]:
     output = {}
 
     # Ensure TIMES names for all attributes
@@ -2210,7 +2247,9 @@ def convert_aliases(input: Dict[str, DataFrame]) -> Dict[str, DataFrame]:
     return output
 
 
-def rename_cgs(input: Dict[str, DataFrame]) -> Dict[str, DataFrame]:
+def rename_cgs(
+    config: datatypes.Config, input: Dict[str, DataFrame]
+) -> Dict[str, DataFrame]:
     output = {}
 
     for table_type, df in input.items():
@@ -2224,7 +2263,9 @@ def rename_cgs(input: Dict[str, DataFrame]) -> Dict[str, DataFrame]:
     return output
 
 
-def apply_more_fixups(input: Dict[str, DataFrame]) -> Dict[str, DataFrame]:
+def apply_more_fixups(
+    config: datatypes.Config, input: Dict[str, DataFrame]
+) -> Dict[str, DataFrame]:
     output = {}
     # TODO: This should only be applied to processes introduced in BASE
     for table_type, df in input.items():
@@ -2278,6 +2319,7 @@ def apply_more_fixups(input: Dict[str, DataFrame]) -> Dict[str, DataFrame]:
 
 
 def expand_rows_parallel(
+    config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     with ProcessPoolExecutor() as executor:


### PR DESCRIPTION
This is a step towards #11 : this PR threads a new object of type `Config` through all transforms. Currently the information read from `times_mappings.txt` and `times-info.json` are kept in the `Config` class. In future we can also add things like `VedaProcessSets` to this class, and any other configuration option / meta information that we need to carry through the pipeline of transforms.