### PR TITLE
Optimize transforms on dicts

### DIFF
--- a/times_reader/transforms.py
+++ b/times_reader/transforms.py
@@ -2278,55 +2278,49 @@ def process_time_slices(
 
 
 def convert_to_string(
-    config: datatypes.Config, input: Dict[str, DataFrame]
+    config: datatypes.Config, tables: Dict[str, DataFrame]
 ) -> Dict[str, DataFrame]:
-    output = {}
-    for key, value in input.items():
-        output[key] = value.map(
+    for key, value in tables.items():
+        tables[key] = value.map(
             lambda x: str(int(x)) if isinstance(x, float) and x.is_integer() else str(x)
         )
-    return output
+    return tables
 
 
 def convert_aliases(
-    config: datatypes.Config, input: Dict[str, DataFrame]
+    config: datatypes.Config, tables: Dict[str, DataFrame]
 ) -> Dict[str, DataFrame]:
-    output = {}
-
     # Ensure TIMES names for all attributes
     replacement_dict = {}
     for k, v in aliases_by_attr.items():
         for alias in v:
             replacement_dict[alias] = k
 
-    for table_type, df in input.items():
+    for table_type, df in tables.items():
         if "attribute" in df.columns:
             df.replace({"attribute": replacement_dict}, inplace=True)
-        output[table_type] = df
+        tables[table_type] = df
 
-    return output
+    return tables
 
 
 def rename_cgs(
-    config: datatypes.Config, input: Dict[str, DataFrame]
+    config: datatypes.Config, tables: Dict[str, DataFrame]
 ) -> Dict[str, DataFrame]:
-    output = {}
-
-    for table_type, df in input.items():
+    for table_type, df in tables.items():
         if table_type == datatypes.Tag.fi_t:
             i = df["other_indexes"].isin(default_pcg_suffixes)
             df.loc[i, "other_indexes"] = (
                 df["techname"].astype(str) + "_" + df["other_indexes"].astype(str)
             )
-        output[table_type] = df
+        tables[table_type] = df
 
-    return output
+    return tables
 
 
 def apply_more_fixups(
     config: datatypes.Config, tables: Dict[str, DataFrame]
 ) -> Dict[str, DataFrame]:
-    output = {}
     # TODO: This should only be applied to processes introduced in BASE
     for table_type, df in tables.items():
         if table_type == datatypes.Tag.fi_t:
@@ -2383,9 +2377,9 @@ def apply_more_fixups(
                     if any(index):
                         df.at[list(index).index(True), "uc_desc"] = uc_n
 
-        output[table_type] = df
+        tables[table_type] = df
 
-    return output
+    return tables
 
 
 def expand_rows_parallel(


### PR DESCRIPTION
Many of the transforms that have the following signature
```python
def foo(
    config: datatypes.Config, tables: Dict[str, DataFrame]
) -> Dict[str, DataFrame]:
```
are unnecessarily creating a new dictionary `output` and returning it. Python dictionaries are mutable:
```python
In [1]: d = {1: 2}

In [2]: def foo(dic):
   ...:     dic[1] = 3
   ...:     return dic
   ...: 

In [3]: d1 = foo(d)

In [4]: d
Out[4]: {1: 3}

In [5]: d1
Out[5]: {1: 3}

In [6]: d is d1
Out[6]: True
```
so it is sufficient to modify `tables` directly.

Also, some transforms iterate through all the items in the input dictionary just to find a single/a few key(s). We can instead do a dictionary lookup which is a faster constant-time operation.