### PR TITLE
Rename normalize_tags_columns_attr and update description

### DIFF
--- a/times_reader/__main__.py
+++ b/times_reader/__main__.py
@@ -54,7 +54,7 @@ def convert_xl_to_times(
         return {}
 
     transform_list = [
-        transforms.normalize_tags_columns_attrs,
+        transforms.normalize_tags_columns,
         transforms.remove_fill_tables,
         transforms.remove_empty_tables,
         lambda config, tables: [transforms.remove_comment_rows(t) for t in tables],

--- a/times_reader/transforms.py
+++ b/times_reader/transforms.py
@@ -492,8 +492,6 @@ def normalize_tags_columns(
     :return:            List of tables in EmbeddedXlTable format with normalzed values.
     """
 
-    # TODO Normalize column names and attribute values in mapping.txt when reading it
-    # TODO Check all string literals left in file
     def normalize(table: datatypes.EmbeddedXlTable) -> datatypes.EmbeddedXlTable:
         # Only uppercase upto ':', the rest can be non-uppercase values like regions
         parts = table.tag.split(":")

--- a/times_reader/transforms.py
+++ b/times_reader/transforms.py
@@ -480,13 +480,12 @@ def remove_empty_tables(
     return [table for table in tables if not discard(table)]
 
 
-def normalize_tags_columns_attrs(
+def normalize_tags_columns(
     config: datatypes.Config,
     tables: List[datatypes.EmbeddedXlTable],
 ) -> List[datatypes.EmbeddedXlTable]:
     """
-    Normalize (uppercase) tags, (lowercase) column names, and (uppercase) values in
-    attribute columns.
+    Normalize (uppercase) tags and (lowercase) column names.
 
 
     :param tables:      List of tables in EmbeddedXlTable format.


### PR DESCRIPTION
This PR renames `normalize_tags_columns_attr` `normalize_tags_columns` and updates its description, since no normalisation is done in this function.