### PR TITLE
CI: bring back subprocess to fix regression tests

### DIFF
--- a/utils/run_benchmarks.py
+++ b/utils/run_benchmarks.py
@@ -196,11 +196,19 @@ def run_benchmark(
         args.append(xl_folder)
     start = time.time()
 
-    # Call the conversion function directly
-    summary = run(parse_args(args))
-
-    # pack the results into a namedtuple pretending to be a return value from a subprocess call (as above).
-    res = namedtuple("stdout", ["stdout", "stderr", "returncode"])(summary, "", 0)
+    res = None
+    if not debug:
+        res = subprocess.run(
+            ["xl2times"] + args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    else:
+        # If debug option is set, run as a function call to allow stepping with a debugger.
+        summary = run(parse_args(args))
+        # pack the results into a namedtuple pretending to be a return value from a subprocess call (as above).
+        res = namedtuple("stdout", ["stdout", "stderr", "returncode"])(summary, "", 0)
 
     runtime = time.time() - start
 


### PR DESCRIPTION
Now I remember why I used subprocess to call `xl2times` from `run_benchmarks.py`: in the CI, when it switches to the main branch, it needs to run the main branch's version of the tool. But if we call the tool as a python function, I think some of the PR version of the tool remains in memory, and we don't get what we want. This looks to be the reason CI is failing on this PR #183 :
https://github.com/etsap-TIMES/xl2times/actions/runs/8020431584/job/21910275023

(The error is that it can't find a file in `xl2times/config/...` that was added by the PR when it is running tests in the main branch.)

This PR undoes the change from #193 that removed the use of subprocess. See also https://github.com/etsap-TIMES/xl2times/pull/193/files?diff=unified&w=0#r1498683705