### PR TITLE
Handle VEDA Excel compatibility cases

### DIFF
--- a/tests/test_excel.py
+++ b/tests/test_excel.py
@@ -1,0 +1,36 @@
+import pandas as pd
+
+from xl2times import excel
+
+
+def test_extract_table_handles_empty_terminal_tag():
+    df = pd.DataFrame([[None, None, "~TFM_DINS-TS"]], dtype=object)
+
+    table = excel.extract_table(
+        tag_row=0,
+        tag_col=2,
+        uc_sets={},
+        df=df,
+        sheetname="SolWin AF",
+        filename="BY_Trans.xlsx",
+    )
+
+    assert table.tag == "~TFM_DINS-TS"
+    assert table.dataframe.empty
+    assert list(table.dataframe.columns) == ["VALUE"]
+
+
+def test_extract_table_handles_tag_with_blank_header_row():
+    df = pd.DataFrame([["~TFM_DINS-TS"], [None]], dtype=object)
+
+    table = excel.extract_table(
+        tag_row=0,
+        tag_col=0,
+        uc_sets={},
+        df=df,
+        sheetname="SolWin AF",
+        filename="BY_Trans.xlsx",
+    )
+
+    assert table.tag == "~TFM_DINS-TS"
+    assert table.dataframe.empty

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -84,7 +84,7 @@ class TestTransforms:
             ),
         ]
 
-        transforms.process_time_periods(None, tables, model)
+        transforms.process_time_periods(config, tables, model)
 
         assert model.time_periods[["year", "b", "e", "m"]].to_dict("records") == [
             {"year": 2022, "b": 2022, "e": 2022, "m": 2022},
@@ -103,7 +103,7 @@ class TestTransforms:
             dataframe=DataFrame({"pset_pn": ["*[_]AFG"], "region": ["OAS"]}),
         )
 
-        [processed] = transforms.process_transform_availability(None, [table], None)
+        [processed] = transforms.process_transform_availability(config, [table], TimesModel())
 
         assert processed.dataframe["value"].iloc[0] == 1
 
@@ -115,9 +115,9 @@ class TestTransforms:
             }
         )
         df2 = transforms.explode_process_commodity_cols(
-            None,  # pyright: ignore
+            config,
             {"name": df.copy()},
-            None,  # pyright: ignore
+            TimesModel(),
         )
         correct = DataFrame(
             {

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -6,6 +6,7 @@ from xl2times import transforms, utils
 from xl2times.datatypes import (
     Config,
     EmbeddedXlTable,
+    Tag,
     TimesModel,
 )
 from xl2times.transforms import (
@@ -41,6 +42,71 @@ def create_config() -> Config:
 
 
 class TestTransforms:
+    def test_process_time_periods_uses_active_milestone_year_definition(self):
+        model = TimesModel()
+        tables = [
+            EmbeddedXlTable(
+                tag=Tag.start_year,
+                uc_sets={},
+                sheetname="TimePeriods",
+                range="B4",
+                filename="SysSettings.xlsx",
+                dataframe=DataFrame({"value": [2022]}),
+            ),
+            EmbeddedXlTable(
+                tag=Tag.active_p_def,
+                uc_sets={},
+                sheetname="TimePeriods",
+                range="B8",
+                filename="SysSettings.xlsx",
+                dataframe=DataFrame({"value": ["msy10_2055"]}),
+            ),
+            EmbeddedXlTable(
+                tag=Tag.time_periods,
+                uc_sets={},
+                sheetname="TimePeriods",
+                range="B12:C23",
+                filename="SysSettings.xlsx",
+                dataframe=DataFrame({"10p2050": [1, 1, 1, 5]}),
+            ),
+            EmbeddedXlTable(
+                tag=Tag.milestoneyears,
+                uc_sets={},
+                sheetname="TimePeriods",
+                range="E12:O33",
+                filename="SysSettings.xlsx",
+                dataframe=DataFrame(
+                    {
+                        "type": ["milestoneyear"] * 4,
+                        "msy10_2055": [2022, 2023, 2024, 2025],
+                    }
+                ),
+            ),
+        ]
+
+        transforms.process_time_periods(None, tables, model)
+
+        assert model.time_periods[["year", "b", "e", "m"]].to_dict("records") == [
+            {"year": 2022, "b": 2022, "e": 2022, "m": 2022},
+            {"year": 2023, "b": 2023, "e": 2023, "m": 2023},
+            {"year": 2024, "b": 2024, "e": 2024, "m": 2024},
+            {"year": 2025, "b": 2025, "e": 2029, "m": 2025},
+        ]
+
+    def test_process_transform_availability_defaults_missing_value_to_one(self):
+        table = EmbeddedXlTable(
+            tag=Tag.tfm_ava,
+            uc_sets={},
+            sheetname="AVA",
+            range="C4:E224",
+            filename="SubRES_Wind-NREL-C_Trans.xlsx",
+            dataframe=DataFrame({"pset_pn": ["*[_]AFG"], "region": ["OAS"]}),
+        )
+
+        [processed] = transforms.process_transform_availability(None, [table], None)
+
+        assert processed.dataframe["value"].iloc[0] == 1
+
     def test_explode_process_commodity_cols(self):
         df = DataFrame(
             {

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -103,7 +103,9 @@ class TestTransforms:
             dataframe=DataFrame({"pset_pn": ["*[_]AFG"], "region": ["OAS"]}),
         )
 
-        [processed] = transforms.process_transform_availability(config, [table], TimesModel())
+        [processed] = transforms.process_transform_availability(
+            config, [table], TimesModel()
+        )
 
         assert processed.dataframe["value"].iloc[0] == 1
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -42,7 +42,7 @@ def config() -> Config:
 
 
 class TestTransforms:
-    def test_process_time_periods_uses_active_milestone_year_definition(self):
+    def test_process_time_periods_uses_active_milestone_year_definition(self, config):
         model = TimesModel()
         tables = [
             EmbeddedXlTable(
@@ -93,7 +93,7 @@ class TestTransforms:
             {"year": 2025, "b": 2025, "e": 2029, "m": 2025},
         ]
 
-    def test_process_transform_availability_defaults_missing_value_to_one(self):
+    def test_process_transform_availability_defaults_missing_value_to_one(self, config):
         table = EmbeddedXlTable(
             tag=Tag.tfm_ava,
             uc_sets={},
@@ -107,7 +107,7 @@ class TestTransforms:
 
         assert processed.dataframe["value"].iloc[0] == 1
 
-    def test_explode_process_commodity_cols(self):
+    def test_explode_process_commodity_cols(self, config):
         df = DataFrame(
             {
                 "process": ["a", "b", ["c", "d"]],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,26 @@
 import pandas as pd
 
 from xl2times import utils
+from xl2times.datatypes import EmbeddedXlTable
 
 
 class TestUtils:
+    def test_apply_composite_tag_accepts_semicolon_defaults(self):
+        table = EmbeddedXlTable(
+            tag="~TFM_INS",
+            defaults="Curr=USD20; Other_Indexes=ACT",
+            uc_sets={},
+            sheetname="New plants OM costs",
+            range="B23:V38",
+            filename="Scen_BaseEXTRA.xlsx",
+            dataframe=pd.DataFrame({"attribute": ["NCAP_FOM"]}),
+        )
+
+        normalized = utils.apply_composite_tag(table)
+
+        assert normalized.dataframe["curr"].iloc[0] == "USD20"
+        assert normalized.dataframe["other_indexes"].iloc[0] == "ACT"
+
     def test_explode(self):
         """Test that explode logics functions correctly."""
         input_df1 = pd.DataFrame(

--- a/xl2times/excel.py
+++ b/xl2times/excel.py
@@ -136,6 +136,8 @@ def extract_table(
         uc_sets = {}
     else:
         header_row = tag_row + 1
+        if header_row >= df.shape[0]:
+            return _empty_table(tag_row, tag_col, uc_sets, df, sheetname, filename)
 
         start_col = tag_col
         while start_col > 0 and not cell_is_empty(df.iloc[header_row, start_col - 1]):
@@ -144,6 +146,9 @@ def extract_table(
         end_col = tag_col
         while end_col < df.shape[1] and not cell_is_empty(df.iloc[header_row, end_col]):
             end_col += 1
+
+        if end_col <= start_col:
+            return _empty_table(tag_row, tag_col, uc_sets, df, sheetname, filename)
 
         end_row = header_row
         while end_row < df.shape[0] and not are_cells_all_empty(
@@ -187,6 +192,32 @@ def extract_table(
         tag=df.iloc[tag_row, tag_col],
         uc_sets=uc_sets,
         dataframe=table_df,
+    )
+
+
+def _empty_table(
+    tag_row: int,
+    tag_col: int,
+    uc_sets: dict[str, str],
+    df: DataFrame,
+    sheetname: str,
+    filename: str,
+) -> datatypes.EmbeddedXlTable:
+    table_range = str(
+        CellRange(
+            min_col=tag_col + 1,
+            min_row=tag_row + 1,
+            max_col=tag_col + 1,
+            max_row=tag_row + 1,
+        )
+    )
+    return datatypes.EmbeddedXlTable(
+        filename=filename,
+        sheetname=sheetname,
+        range=table_range,
+        tag=df.iloc[tag_row, tag_col],
+        uc_sets=uc_sets,
+        dataframe=DataFrame(columns=["VALUE"]),
     )
 
 

--- a/xl2times/transforms.py
+++ b/xl2times/transforms.py
@@ -1028,16 +1028,79 @@ def create_model_units(
     return tables
 
 
+def _numeric_period_series(values: pd.Series) -> pd.Series:
+    return (
+        pd.to_numeric(values, errors="coerce")
+        .dropna()
+        .astype(int)
+        .reset_index(drop=True)
+    )
+
+
 def process_time_periods(
     config: Config,
     tables: list[EmbeddedXlTable],
     model: TimesModel,
 ) -> list[EmbeddedXlTable]:
     model.start_year = utils.get_scalar(Tag.start_year, tables)
-    active_pdef = utils.get_scalar(Tag.active_p_def, tables)
+    active_pdef = str(utils.get_scalar(Tag.active_p_def, tables)).lower()
     df = utils.single_table(tables, Tag.time_periods).dataframe
 
-    active_series = df[active_pdef.lower()]
+    if active_pdef in df.columns:
+        active_series = df[active_pdef]
+        # Remove empty rows
+        active_series = active_series.dropna()
+
+        df = pd.DataFrame({"d": active_series})
+        # Start years = start year, then cumulative sum of period durations
+        df["b"] = (active_series.cumsum() + model.start_year).shift(
+            1, fill_value=model.start_year
+        )
+        df["e"] = df.b + df.d - 1
+        df["m"] = df.b + ((df.d - 1) // 2)
+        df["year"] = df.m
+
+        model.time_periods = df.astype(int)
+
+        return tables
+
+    milestone_table = utils.single_table(tables, Tag.milestoneyears).dataframe
+    if active_pdef not in milestone_table.columns:
+        raise KeyError(active_pdef)
+
+    milestone_rows = milestone_table
+    if "type" in milestone_rows.columns:
+        milestone_rows = milestone_rows[
+            milestone_rows["type"].astype(str).str.lower() == "milestoneyear"
+        ]
+    milestones = _numeric_period_series(milestone_rows[active_pdef])
+    if milestones.empty:
+        raise KeyError(active_pdef)
+
+    duration_candidates = []
+    for column in df.columns:
+        values = _numeric_period_series(df[column])
+        if not values.empty:
+            duration_candidates.append((column, values))
+    if not duration_candidates:
+        raise KeyError(active_pdef)
+
+    matching = [
+        (column, values)
+        for column, values in duration_candidates
+        if len(values) == len(milestones)
+    ]
+    duration_col, durations = (matching or duration_candidates)[0]
+    n_periods = min(len(durations), len(milestones))
+    if len(durations) != len(milestones):
+        logger.warning(
+            f"ActivePDef {active_pdef} has {len(milestones)} milestone years, but "
+            f"~TimePeriods/{duration_col} has {len(durations)} duration rows; "
+            f"using first {n_periods}."
+        )
+
+    active_series = durations.iloc[:n_periods]
+    milestones = milestones.iloc[:n_periods]
     # Remove empty rows
     active_series = active_series.dropna()
 
@@ -1047,7 +1110,7 @@ def process_time_periods(
         1, fill_value=model.start_year
     )
     df["e"] = df.b + df.d - 1
-    df["m"] = df.b + ((df.d - 1) // 2)
+    df["m"] = milestones.values
     df["year"] = df.m
 
     model.time_periods = df.astype(int)
@@ -2194,9 +2257,11 @@ def process_transform_availability(
     result = []
     for table in tables:
         if table.tag == Tag.tfm_ava:
-            result.append(
-                replace(table, dataframe=table.dataframe.dropna(subset="value"))
-            )
+            df = table.dataframe
+            if "value" not in df.columns:
+                df = df.copy()
+                df["value"] = 1
+            result.append(replace(table, dataframe=df.dropna(subset="value")))
         else:
             result.append(table)
 

--- a/xl2times/utils.py
+++ b/xl2times/utils.py
@@ -59,13 +59,17 @@ def apply_composite_tag(table: datatypes.EmbeddedXlTable) -> datatypes.EmbeddedX
     df = table.dataframe
     # Check for ANSWER-style defaults
     if "=" in defaults:
-        # Split multiple comma-separated defaults / make defaults a list
-        defaults = defaults.split(",")
+        # Split multiple comma/semicolon-separated defaults / make defaults a list
+        defaults = [
+            default.strip()
+            for default in defaults.replace(";", ",").split(",")
+            if default.strip()
+        ]
         # Check whether there are invalid values on the list
         invalid_defaults = [default for default in defaults if "=" not in default]
         if invalid_defaults:
             logger.warning(f"Expected ANSWER-style defaults, got {invalid_defaults}")
-        defaults = [default.split("=") for default in defaults if "=" in default]
+        defaults = [default.split("=", 1) for default in defaults if "=" in default]
         # TODO: check whether a column is allowed in a particular table type
         for col, val in defaults:
             colname = col.lower()


### PR DESCRIPTION
## Summary

This PR fixes several VEDA Excel compatibility cases encountered while converting a production IEMM/VEDA 2.0 model with xl2times:

- Treat empty terminal VEDA tags as empty tables instead of raising an index error during extraction.
- Accept semicolon-separated ANSWER-style defaults such as `Curr=USD20; Other_Indexes=ACT`.
- Allow `~ActivePDef` to select a period definition from `~MilestoneYears` when `~TimePeriods` only provides duration rows under a different column name.
- Default `~TFM_AVA` tables without an explicit `value` column to availability value `1` before dropping missing values.

## Context

The motivating failure was an `IndexError` while reading `BY_Trans.xlsx`, sheet `SolWin AF`, tag `~TFM_DINS-TS`, where the tag appears as an empty terminal declaration with no row below it. After that was fixed, the same model exposed the other compatibility cases covered here.

## Validation

- `python3 -m pytest tests/test_excel.py tests/test_utils.py::TestUtils::test_apply_composite_tag_accepts_semicolon_defaults tests/test_transforms.py::TestTransforms::test_process_time_periods_uses_active_milestone_year_definition tests/test_transforms.py::TestTransforms::test_process_transform_availability_defaults_missing_value_to_one`
- `python3 -m pytest tests`
- `python3 -m black --check xl2times/excel.py xl2times/transforms.py xl2times/utils.py tests/test_excel.py tests/test_transforms.py tests/test_utils.py`
- `git diff --check`

Note: `python3 -m ruff check ...` still reports pre-existing lint issues in the touched upstream files, unrelated to this patch.